### PR TITLE
Feature/refactor config

### DIFF
--- a/src/yio-interface/configinterface.h
+++ b/src/yio-interface/configinterface.h
@@ -53,9 +53,7 @@ class ConfigInterface {
     virtual QVariantMap  getIntegration(const QString& type)     = 0;
     virtual QVariantMap  getAllEntities()                        = 0;
     virtual QVariantList getEntities(const QString& type)        = 0;
-
-    //    virtual QVariant getContextProperty(const QString& name) = 0;
-    virtual QObject* getQMLObject(const QString& name) = 0;
+    virtual QObject*     getQMLObject(const QString& name)       = 0;
 };
 
 QT_BEGIN_NAMESPACE

--- a/src/yio-interface/entities/entitiesinterface.h
+++ b/src/yio-interface/entities/entitiesinterface.h
@@ -51,6 +51,9 @@ class EntitiesInterface {
 
     // get a list of supported entities
     virtual QStringList supportedEntities() = 0;
+
+    // checks if a type is supported
+    virtual bool isSupportedEntityType(const QString& type) = 0;
 };
 
 QT_BEGIN_NAMESPACE

--- a/src/yio-interface/entities/entitiesinterface.h
+++ b/src/yio-interface/entities/entitiesinterface.h
@@ -50,7 +50,7 @@ class EntitiesInterface {
     virtual EntityInterface* getEntityInterface(const QString& entity_id) = 0;
 
     // get a list of supported entities
-    virtual QStringList supported_entities() = 0;
+    virtual QStringList supportedEntities() = 0;
 };
 
 QT_BEGIN_NAMESPACE

--- a/src/yio-interface/entities/entitiesinterface.h
+++ b/src/yio-interface/entities/entitiesinterface.h
@@ -48,6 +48,9 @@ class EntitiesInterface {
 
     // get entity interface by entity_id
     virtual EntityInterface* getEntityInterface(const QString& entity_id) = 0;
+
+    // get a list of supported entities
+    virtual QStringList supported_entities() = 0;
 };
 
 QT_BEGIN_NAMESPACE

--- a/src/yio-interface/integrationinterface.h
+++ b/src/yio-interface/integrationinterface.h
@@ -80,7 +80,7 @@ class IntegrationInterface {
      */
     virtual QString friendlyName() = 0;
 
- public slots:
+ public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
     /**
      * @brief connect Must be implemented by integration
      */

--- a/src/yio-interface/integrationinterface.h
+++ b/src/yio-interface/integrationinterface.h
@@ -57,7 +57,7 @@ class IntegrationInterface {
     /**
      * @brief getAllAvailableEntities Can be implemented by integration
      */
-    virtual QStringList getAllAvailableEntities() = 0;
+    virtual QVariantMap getAllAvailableEntities() = 0;
 
     /**
      * @brief sendCommand Must be implemented as Q_INVOKABLE
@@ -72,7 +72,7 @@ class IntegrationInterface {
      * @brief state Returns the current state. See States enum definition.
      * @details A Q_PROPERTY must be implemented with this method as READ accessor.
      */
-    virtual int     state() = 0;
+    virtual int state() = 0;
 
     /**
      * @brief state Returns the integration identifier.

--- a/src/yio-interface/integrationinterface.h
+++ b/src/yio-interface/integrationinterface.h
@@ -61,6 +61,17 @@ class IntegrationInterface {
 
     /**
      * @brief sendCommand Must be implemented as Q_INVOKABLE
+     * @param entity_id
+     * @param type
+     * @param integration
+     * @param friendly_name
+     * @param supported_features
+     */
+    virtual bool addAvailableEntity(const QString& entity_id, const QString& type, const QString& integration,
+                                    const QString& friendly_name, const QStringList& supported_features) = 0;
+
+    /**
+     * @brief sendCommand Must be implemented as Q_INVOKABLE
      * @param type
      * @param entity_id
      * @param command

--- a/src/yio-interface/integrationinterface.h
+++ b/src/yio-interface/integrationinterface.h
@@ -63,11 +63,11 @@ class IntegrationInterface {
 
     /**
      * @brief sendCommand Must be implemented as Q_INVOKABLE
-     * @param entity_id
+     * @param entityId
      * @param type
      * @param integration
-     * @param friendly_name
-     * @param supported_features
+     * @param friendlyName
+     * @param supportedFeatures
      */
     virtual bool addAvailableEntity(const QString& entityId, const QString& type, const QString& integration,
                                     const QString& friendlyName, const QStringList& supportedFeatures) = 0;
@@ -75,11 +75,11 @@ class IntegrationInterface {
     /**
      * @brief sendCommand Must be implemented as Q_INVOKABLE
      * @param type
-     * @param entity_id
+     * @param entityId
      * @param command
      * @param param
      */
-    virtual void sendCommand(const QString& type, const QString& entity_id, int command, const QVariant& param) = 0;
+    virtual void sendCommand(const QString& type, const QString& entityId, int command, const QVariant& param) = 0;
 
     /**
      * @brief state Returns the current state. See States enum definition.

--- a/src/yio-interface/integrationinterface.h
+++ b/src/yio-interface/integrationinterface.h
@@ -69,8 +69,8 @@ class IntegrationInterface {
      * @param friendly_name
      * @param supported_features
      */
-    virtual bool addAvailableEntity(const QString& entity_id, const QString& type, const QString& integration,
-                                    const QString& friendly_name, const QStringList& supported_features) = 0;
+    virtual bool addAvailableEntity(const QString& entityId, const QString& type, const QString& integration,
+                                    const QString& friendlyName, const QStringList& supportedFeatures) = 0;
 
     /**
      * @brief sendCommand Must be implemented as Q_INVOKABLE

--- a/src/yio-interface/integrationinterface.h
+++ b/src/yio-interface/integrationinterface.h
@@ -57,7 +57,7 @@ class IntegrationInterface {
     /**
      * @brief getAllAvailableEntities Can be implemented by integration
      */
-    virtual QVariantMap getAllAvailableEntities() = 0;
+    virtual QVariantList getAllAvailableEntities() = 0;
 
     /**
      * @brief sendCommand Must be implemented as Q_INVOKABLE

--- a/src/yio-interface/integrationinterface.h
+++ b/src/yio-interface/integrationinterface.h
@@ -35,34 +35,15 @@ class IntegrationInterface {
     virtual ~IntegrationInterface();
 
     /**
-     * @brief connect Must be implemented by integration as Q_INVOKABLE
-     */
-    virtual void connect() = 0;
-
-    /**
-     * @brief disconnect Must be implemented by integration as Q_INVOKABLE
-     */
-    virtual void disconnect() = 0;
-
-    /**
-     * @brief enterStandby Can be implemented by integration as Q_INVOKABLE
-     */
-    virtual void enterStandby() = 0;
-
-    /**
-     * @brief leaveStandby Can be implemented by integration as Q_INVOKABLE
-     */
-    virtual void leaveStandby() = 0;
-
-    /**
      * @brief getAllAvailableEntities Can be implemented by integration
      * @returns list of QVariantMap
+     * @details
      * https://github.com/YIO-Remote/documentation/wiki/developer-API-remote#get-available-entities-json-of-loaded-entities
      */
     virtual QVariantList getAllAvailableEntities() = 0;
 
     /**
-     * @brief sendCommand Must be implemented as Q_INVOKABLE
+     * @brief addAvailableEntity
      * @param entityId
      * @param type
      * @param integration
@@ -73,7 +54,7 @@ class IntegrationInterface {
                                     const QString& friendlyName, const QStringList& supportedFeatures) = 0;
 
     /**
-     * @brief sendCommand Must be implemented as Q_INVOKABLE
+     * @brief sendCommand Must be implemented
      * @param type
      * @param entityId
      * @param command
@@ -98,6 +79,27 @@ class IntegrationInterface {
      * @details A Q_PROPERTY must be implemented with this method as READ accessor.
      */
     virtual QString friendlyName() = 0;
+
+ public slots:
+    /**
+     * @brief connect Must be implemented by integration
+     */
+    virtual void connect() = 0;
+
+    /**
+     * @brief disconnect Must be implemented by integration
+     */
+    virtual void disconnect() = 0;
+
+    /**
+     * @brief enterStandby Can be implemented by integration
+     */
+    virtual void enterStandby() = 0;
+
+    /**
+     * @brief leaveStandby Can be implemented by integration
+     */
+    virtual void leaveStandby() = 0;
 };
 
 QT_BEGIN_NAMESPACE

--- a/src/yio-interface/integrationinterface.h
+++ b/src/yio-interface/integrationinterface.h
@@ -56,6 +56,8 @@ class IntegrationInterface {
 
     /**
      * @brief getAllAvailableEntities Can be implemented by integration
+     * @returns list of QVariantMap
+     * https://github.com/YIO-Remote/documentation/wiki/developer-API-remote#get-available-entities-json-of-loaded-entities
      */
     virtual QVariantList getAllAvailableEntities() = 0;
 

--- a/src/yio-interface/yioapiinterface.h
+++ b/src/yio-interface/yioapiinterface.h
@@ -34,16 +34,15 @@ class YioAPIInterface : public QObject {
  public:
     virtual ~YioAPIInterface() {}
 
-    virtual void start() = 0;
-    virtual void stop() = 0;
+    virtual void start()                      = 0;
+    virtual void stop()                       = 0;
     virtual void sendMessage(QString message) = 0;
 
     // CONFIG MANIPULATION METHODS
     virtual QVariantMap getConfig() = 0;
-    virtual bool        addEntityToConfig(QVariantMap entity) = 0;
 
     // NETWORK SERVICES DISCOVERY
-    virtual void discoverNetworkServices() = 0;
+    virtual void discoverNetworkServices()             = 0;
     virtual void discoverNetworkServices(QString mdns) = 0;
 
  signals:

--- a/src/yio-plugin/integration.cpp
+++ b/src/yio-plugin/integration.cpp
@@ -71,6 +71,13 @@ Integration::~Integration() {}
 
 bool Integration::addAvailableEntity(const QString& entity_id, const QString& type, const QString& integration,
                                      const QString& friendly_name, const QStringList& supported_features) {
+    // if the entity is already in the list, skip
+    for (int i = 0; i < m_allAvailableEntities.length(); i++) {
+        if (m_allAvailableEntities[i].toMap().value("entity_id").toString() == entity_id) {
+            return false;
+        }
+    }
+
     if (m_entities->supportedEntities().contains(type)) {
         QVariantMap entity;
         entity.insert("entity_id", entity_id);

--- a/src/yio-plugin/integration.cpp
+++ b/src/yio-plugin/integration.cpp
@@ -21,19 +21,20 @@
  *****************************************************************************/
 
 #include "integration.h"
+#include
 
-const QString Integration::KEY_ID = CFG_KEY_ID;
-const QString Integration::KEY_FRIENDLYNAME = CFG_KEY_FRIENDLYNAME;
-const QString Integration::KEY_ENTITY_ID = CFG_KEY_ENTITY_ID;
-const QString Integration::KEY_AREA = CFG_KEY_AREA;
-const QString Integration::KEY_INTEGRATION = CFG_KEY_INTEGRATION;
+const QString Integration::KEY_ID                 = CFG_KEY_ID;
+const QString Integration::KEY_FRIENDLYNAME       = CFG_KEY_FRIENDLYNAME;
+const QString Integration::KEY_ENTITY_ID          = CFG_KEY_ENTITY_ID;
+const QString Integration::KEY_AREA               = CFG_KEY_AREA;
+const QString Integration::KEY_INTEGRATION        = CFG_KEY_INTEGRATION;
 const QString Integration::KEY_SUPPORTED_FEATURES = CFG_KEY_SUPPORTED_FEATURES;
-const QString Integration::KEY_TYPE = CFG_KEY_TYPE;
-const QString Integration::KEY_MDNS = CFG_KEY_MDNS;
-const QString Integration::KEY_WORKERTHREAD = CFG_KEY_WORKERTHREAD;
-const QString Integration::OBJ_DATA = CFG_OBJ_DATA;
-const QString Integration::KEY_DATA_IP = CFG_KEY_DATA_IP;
-const QString Integration::KEY_DATA_TOKEN = CFG_KEY_DATA_TOKEN;
+const QString Integration::KEY_TYPE               = CFG_KEY_TYPE;
+const QString Integration::KEY_MDNS               = CFG_KEY_MDNS;
+const QString Integration::KEY_WORKERTHREAD       = CFG_KEY_WORKERTHREAD;
+const QString Integration::OBJ_DATA               = CFG_OBJ_DATA;
+const QString Integration::KEY_DATA_IP            = CFG_KEY_DATA_IP;
+const QString Integration::KEY_DATA_TOKEN         = CFG_KEY_DATA_TOKEN;
 
 IntegrationInterface::~IntegrationInterface() {}
 
@@ -68,6 +69,23 @@ Integration::Integration(Plugin* plugin)
       m_logCategory(plugin->m_logCategory) {}
 
 Integration::~Integration() {}
+
+bool Integration::addAvailableEntity(const QString& entity_id, const QString& type, const QString& integration,
+                                     const QString& friendly_name, const QStringList& supported_features) {
+    if (m_entities->supported_entities().contains(type)) {
+        QVariantMap entity;
+        entity.insert("entity_id", entity_id);
+        entity.insert("type", type);
+        entity.insert("integration", integration);
+        entity.insert("friendly_name", friendly_name);
+        entity.insert("supported_features", supported_features);
+        m_allAvailableEntities.append(entity);
+        return true;
+    } else {
+        // return false if the type is not supported
+        return false;
+    }
+}
 
 void Integration::setState(int state) {
     if (state == m_state) {

--- a/src/yio-plugin/integration.cpp
+++ b/src/yio-plugin/integration.cpp
@@ -21,7 +21,6 @@
  *****************************************************************************/
 
 #include "integration.h"
-#include
 
 const QString Integration::KEY_ID                 = CFG_KEY_ID;
 const QString Integration::KEY_FRIENDLYNAME       = CFG_KEY_FRIENDLYNAME;
@@ -72,7 +71,7 @@ Integration::~Integration() {}
 
 bool Integration::addAvailableEntity(const QString& entity_id, const QString& type, const QString& integration,
                                      const QString& friendly_name, const QStringList& supported_features) {
-    if (m_entities->supported_entities().contains(type)) {
+    if (m_entities->supportedEntities().contains(type)) {
         QVariantMap entity;
         entity.insert("entity_id", entity_id);
         entity.insert("type", type);

--- a/src/yio-plugin/integration.cpp
+++ b/src/yio-plugin/integration.cpp
@@ -78,7 +78,7 @@ bool Integration::addAvailableEntity(const QString& entity_id, const QString& ty
         }
     }
 
-    if (m_entities->supportedEntities().contains(type)) {
+    if (m_entities->isSupportedEntityType(type)) {
         QVariantMap entity;
         entity.insert("entity_id", entity_id);
         entity.insert("type", type);

--- a/src/yio-plugin/integration.cpp
+++ b/src/yio-plugin/integration.cpp
@@ -69,22 +69,22 @@ Integration::Integration(Plugin* plugin)
 
 Integration::~Integration() {}
 
-bool Integration::addAvailableEntity(const QString& entity_id, const QString& type, const QString& integration,
-                                     const QString& friendly_name, const QStringList& supported_features) {
+bool Integration::addAvailableEntity(const QString& entityId, const QString& type, const QString& integration,
+                                     const QString& friendlyName, const QStringList& supportedFeatures) {
     // if the entity is already in the list, skip
     for (int i = 0; i < m_allAvailableEntities.length(); i++) {
-        if (m_allAvailableEntities[i].toMap().value("entity_id").toString() == entity_id) {
+        if (m_allAvailableEntities[i].toMap().value(Integration::KEY_ENTITY_ID).toString() == entityId) {
             return false;
         }
     }
 
     if (m_entities->isSupportedEntityType(type)) {
         QVariantMap entity;
-        entity.insert("entity_id", entity_id);
-        entity.insert("type", type);
-        entity.insert("integration", integration);
-        entity.insert("friendly_name", friendly_name);
-        entity.insert("supported_features", supported_features);
+        entity.insert(Integration::KEY_ENTITY_ID, entityId);
+        entity.insert(Integration::KEY_TYPE, type);
+        entity.insert(Integration::KEY_INTEGRATION, integration);
+        entity.insert(Integration::KEY_FRIENDLYNAME, friendlyName);
+        entity.insert(Integration::KEY_SUPPORTED_FEATURES, supportedFeatures);
         m_allAvailableEntities.append(entity);
         return true;
     } else {

--- a/src/yio-plugin/integration.h
+++ b/src/yio-plugin/integration.h
@@ -55,33 +55,34 @@ class Integration : public QObject, public IntegrationInterface {
                 YioAPIInterface* api, ConfigInterface* configObj, Plugin* plugin);
     explicit Integration(Plugin* plugin);
 
-    ~Integration();
+    ~Integration() override;
 
     Q_PROPERTY(int state READ state NOTIFY stateChanged)
 
-    Q_INVOKABLE void connect()    = 0;  // Must be implemented by integration
-    Q_INVOKABLE void disconnect() = 0;  // Must be implemented by integration
-    void             enterStandby() {}  // Can be overriden by integration
-    void             leaveStandby() {}  // Can be overriden by integration
-    QVariantList     getAllAvailableEntities() { return m_allAvailableEntities; }
+    Q_INVOKABLE void connect() override    = 0;  // Must be implemented by integration
+    Q_INVOKABLE void disconnect() override = 0;  // Must be implemented by integration
+    void             enterStandby() override {}  // Can be overriden by integration
+    void             leaveStandby() override {}  // Can be overriden by integration
+    QVariantList     getAllAvailableEntities() override { return m_allAvailableEntities; }
     bool             addAvailableEntity(const QString& entityId, const QString& type, const QString& integration,
-                                        const QString& friendlyName, const QStringList& supportedFeatures);
-    Q_INVOKABLE void sendCommand(const QString& type, const QString& entity_id, int command, const QVariant& param) = 0;
+                                        const QString& friendlyName, const QStringList& supportedFeatures) override;
+    Q_INVOKABLE void sendCommand(const QString& type, const QString& entity_id, int command,
+                                 const QVariant& param) override = 0;
 
     // get the state
-    int state() { return m_state; }
+    int state() override { return m_state; }
 
     // set the state
     void setState(int state);
 
     // get the id of the integration
-    QString integrationId() { return m_integrationId; }
+    QString integrationId() override { return m_integrationId; }
 
     // set the id of the integration
     void setIntegrationId(QString value) { m_integrationId = value; }
 
     // get the friendly name of the integration
-    QString friendlyName() { return m_friendlyName; }
+    QString friendlyName() override { return m_friendlyName; }
 
     // set the friendly name of the integration
     void setFriendlyName(QString value) { m_friendlyName = value; }

--- a/src/yio-plugin/integration.h
+++ b/src/yio-plugin/integration.h
@@ -101,4 +101,8 @@ class Integration : public QObject, public IntegrationInterface {
     ConfigInterface*        m_config;
     QLoggingCategory&       m_logCategory;
     QVariantList            m_allAvailableEntities;
+    /// containts QVariantMap objects with the following keys
+    /// "entity_id": entity id
+    /// "type": type of entity, like light
+    /// "integration_id": id of the integration controlling the entity
 };

--- a/src/yio-plugin/integration.h
+++ b/src/yio-plugin/integration.h
@@ -64,8 +64,8 @@ class Integration : public QObject, public IntegrationInterface {
     void             enterStandby() {}  // Can be overriden by integration
     void             leaveStandby() {}  // Can be overriden by integration
     QVariantList     getAllAvailableEntities() { return m_allAvailableEntities; }
-    bool             addAvailableEntity(const QString& entity_id, const QString& type, const QString& integration,
-                                        const QString& friendly_name, const QStringList& supported_features);
+    bool             addAvailableEntity(const QString& entityId, const QString& type, const QString& integration,
+                                        const QString& friendlyName, const QStringList& supportedFeatures);
     Q_INVOKABLE void sendCommand(const QString& type, const QString& entity_id, int command, const QVariant& param) = 0;
 
     // get the state

--- a/src/yio-plugin/integration.h
+++ b/src/yio-plugin/integration.h
@@ -63,7 +63,7 @@ class Integration : public QObject, public IntegrationInterface {
     Q_INVOKABLE void disconnect() = 0;                                             // Must be implemented by integration
     void             enterStandby() {}                                             // Can be overriden by integration
     void             leaveStandby() {}                                             // Can be overriden by integration
-    QStringList      getAllAvailableEntities() { return m_allAvailableEntities; }  // Can be overriden by integration
+    QVariantMap      getAllAvailableEntities() { return m_allAvailableEntities; }  // Can be overriden by integration
     Q_INVOKABLE void sendCommand(const QString& type, const QString& entity_id, int command, const QVariant& param) = 0;
 
     // get the state
@@ -100,5 +100,5 @@ class Integration : public QObject, public IntegrationInterface {
     YioAPIInterface*        m_yioapi;
     ConfigInterface*        m_config;
     QLoggingCategory&       m_logCategory;
-    QStringList             m_allAvailableEntities;
+    QVariantMap             m_allAvailableEntities;
 };

--- a/src/yio-plugin/integration.h
+++ b/src/yio-plugin/integration.h
@@ -63,7 +63,7 @@ class Integration : public QObject, public IntegrationInterface {
     Q_INVOKABLE void disconnect() = 0;                                             // Must be implemented by integration
     void             enterStandby() {}                                             // Can be overriden by integration
     void             leaveStandby() {}                                             // Can be overriden by integration
-    QVariantMap      getAllAvailableEntities() { return m_allAvailableEntities; }  // Can be overriden by integration
+    QVariantList     getAllAvailableEntities() { return m_allAvailableEntities; }  // Can be overriden by integration
     Q_INVOKABLE void sendCommand(const QString& type, const QString& entity_id, int command, const QVariant& param) = 0;
 
     // get the state
@@ -100,5 +100,5 @@ class Integration : public QObject, public IntegrationInterface {
     YioAPIInterface*        m_yioapi;
     ConfigInterface*        m_config;
     QLoggingCategory&       m_logCategory;
-    QVariantMap             m_allAvailableEntities;
+    QVariantList            m_allAvailableEntities;
 };

--- a/src/yio-plugin/integration.h
+++ b/src/yio-plugin/integration.h
@@ -59,11 +59,13 @@ class Integration : public QObject, public IntegrationInterface {
 
     Q_PROPERTY(int state READ state NOTIFY stateChanged)
 
-    Q_INVOKABLE void connect()    = 0;                                             // Must be implemented by integration
-    Q_INVOKABLE void disconnect() = 0;                                             // Must be implemented by integration
-    void             enterStandby() {}                                             // Can be overriden by integration
-    void             leaveStandby() {}                                             // Can be overriden by integration
-    QVariantList     getAllAvailableEntities() { return m_allAvailableEntities; }  // Can be overriden by integration
+    Q_INVOKABLE void connect()    = 0;  // Must be implemented by integration
+    Q_INVOKABLE void disconnect() = 0;  // Must be implemented by integration
+    void             enterStandby() {}  // Can be overriden by integration
+    void             leaveStandby() {}  // Can be overriden by integration
+    QVariantList     getAllAvailableEntities() { return m_allAvailableEntities; }
+    bool             addAvailableEntity(const QString& entity_id, const QString& type, const QString& integration,
+                                        const QString& friendly_name, const QStringList& supported_features);
     Q_INVOKABLE void sendCommand(const QString& type, const QString& entity_id, int command, const QVariant& param) = 0;
 
     // get the state
@@ -101,8 +103,4 @@ class Integration : public QObject, public IntegrationInterface {
     ConfigInterface*        m_config;
     QLoggingCategory&       m_logCategory;
     QVariantList            m_allAvailableEntities;
-    /// containts QVariantMap objects with the following keys
-    /// "entity_id": entity id
-    /// "type": type of entity, like light
-    /// "integration_id": id of the integration controlling the entity
 };

--- a/src/yio-plugin/integration.h
+++ b/src/yio-plugin/integration.h
@@ -59,15 +59,10 @@ class Integration : public QObject, public IntegrationInterface {
 
     Q_PROPERTY(int state READ state NOTIFY stateChanged)
 
-    Q_INVOKABLE void connect() override    = 0;  // Must be implemented by integration
-    Q_INVOKABLE void disconnect() override = 0;  // Must be implemented by integration
-    void             enterStandby() override {}  // Can be overriden by integration
-    void             leaveStandby() override {}  // Can be overriden by integration
-    QVariantList     getAllAvailableEntities() override { return m_allAvailableEntities; }
-    bool             addAvailableEntity(const QString& entityId, const QString& type, const QString& integration,
-                                        const QString& friendlyName, const QStringList& supportedFeatures) override;
-    Q_INVOKABLE void sendCommand(const QString& type, const QString& entityId, int command,
-                                 const QVariant& param) override = 0;
+    QVariantList getAllAvailableEntities() override { return m_allAvailableEntities; }
+    bool         addAvailableEntity(const QString& entityId, const QString& type, const QString& integration,
+                                    const QString& friendlyName, const QStringList& supportedFeatures) override;
+    void sendCommand(const QString& type, const QString& entityId, int command, const QVariant& param) override = 0;
 
     // get the state
     int state() override { return m_state; }
@@ -92,6 +87,12 @@ class Integration : public QObject, public IntegrationInterface {
     void connecting();
     void disconnected();
     void stateChanged();
+
+ public slots:
+    void connect() override    = 0;  // Must be implemented by integration
+    void disconnect() override = 0;  // Must be implemented by integration
+    void enterStandby() override {}  // Can be overriden by integration
+    void leaveStandby() override {}  // Can be overriden by integration
 
  protected:
     int                     m_state;

--- a/src/yio-plugin/integration.h
+++ b/src/yio-plugin/integration.h
@@ -66,7 +66,7 @@ class Integration : public QObject, public IntegrationInterface {
     QVariantList     getAllAvailableEntities() override { return m_allAvailableEntities; }
     bool             addAvailableEntity(const QString& entityId, const QString& type, const QString& integration,
                                         const QString& friendlyName, const QStringList& supportedFeatures) override;
-    Q_INVOKABLE void sendCommand(const QString& type, const QString& entity_id, int command,
+    Q_INVOKABLE void sendCommand(const QString& type, const QString& entityId, int command,
                                  const QVariant& param) override = 0;
 
     // get the state

--- a/src/yio-plugin/integration.h
+++ b/src/yio-plugin/integration.h
@@ -88,7 +88,7 @@ class Integration : public QObject, public IntegrationInterface {
     void disconnected();
     void stateChanged();
 
- public slots:
+ public slots:                       // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
     void connect() override    = 0;  // Must be implemented by integration
     void disconnect() override = 0;  // Must be implemented by integration
     void enterStandby() override {}  // Can be overriden by integration

--- a/src/yio-plugin/integration_threadadapter.cpp
+++ b/src/yio-plugin/integration_threadadapter.cpp
@@ -75,10 +75,10 @@ QVariantList IntegrationThreadAdapter::getAllAvailableEntities() {
     return m_integration.getAllAvailableEntities();
 }
 
-void IntegrationThreadAdapter::sendCommand(const QString& type, const QString& entity_id, int command,
+void IntegrationThreadAdapter::sendCommand(const QString& type, const QString& entityId, int command,
                                            const QVariant& param) {
-    qCDebug(m_logCategory) << "ThreadAdapter sendCommand" << type << entity_id << command << param;
-    emit sendCommandSignal(type, entity_id, command, param);
+    qCDebug(m_logCategory) << "ThreadAdapter sendCommand" << type << entityId << command << param;
+    emit sendCommandSignal(type, entityId, command, param);
 }
 
 void IntegrationThreadAdapter::onStateChanged() {

--- a/src/yio-plugin/integration_threadadapter.cpp
+++ b/src/yio-plugin/integration_threadadapter.cpp
@@ -70,7 +70,7 @@ void IntegrationThreadAdapter::leaveStandby() {
     emit leaveStandbySignal();
 }
 
-QStringList IntegrationThreadAdapter::getAllAvailableEntities() {
+QVariantList IntegrationThreadAdapter::getAllAvailableEntities() {
     qCDebug(m_logCategory) << "ThreadAdapter getAllAvailableEntities";
     return m_integration.getAllAvailableEntities();
 }

--- a/src/yio-plugin/integration_threadadapter.h
+++ b/src/yio-plugin/integration_threadadapter.h
@@ -42,18 +42,18 @@ class IntegrationThreadAdapter : public Integration {
     ~IntegrationThreadAdapter() override;
 
  public slots:  // NOLINT open issue: https://github.com/cpplint/cpplint/pull/99
+    void connect() override;
+    void disconnect() override;
+    void enterStandby() override;
+    void leaveStandby() override;
+
     // set the state
     void onStateChanged();
 
     // IntegrationInterface
  public:
-    Q_INVOKABLE void connect() override;
-    Q_INVOKABLE void disconnect() override;
-    void             enterStandby() override;
-    void             leaveStandby() override;
-    QVariantList     getAllAvailableEntities() override;
-    Q_INVOKABLE void sendCommand(const QString& type, const QString& entityId, int command,
-                                 const QVariant& param) override;
+    QVariantList getAllAvailableEntities() override;
+    void         sendCommand(const QString& type, const QString& entityId, int command, const QVariant& param) override;
 
  signals:
     void connectSignal();

--- a/src/yio-plugin/integration_threadadapter.h
+++ b/src/yio-plugin/integration_threadadapter.h
@@ -51,7 +51,7 @@ class IntegrationThreadAdapter : public Integration {
     Q_INVOKABLE void disconnect() override;
     void             enterStandby() override;
     void             leaveStandby() override;
-    QStringList      getAllAvailableEntities() override;
+    QVariantList     getAllAvailableEntities() override;
     Q_INVOKABLE void sendCommand(const QString& type, const QString& entity_id, int command,
                                  const QVariant& param) override;
 

--- a/src/yio-plugin/integration_threadadapter.h
+++ b/src/yio-plugin/integration_threadadapter.h
@@ -52,7 +52,7 @@ class IntegrationThreadAdapter : public Integration {
     void             enterStandby() override;
     void             leaveStandby() override;
     QVariantList     getAllAvailableEntities() override;
-    Q_INVOKABLE void sendCommand(const QString& type, const QString& entity_id, int command,
+    Q_INVOKABLE void sendCommand(const QString& type, const QString& entityId, int command,
                                  const QVariant& param) override;
 
  signals:
@@ -60,7 +60,7 @@ class IntegrationThreadAdapter : public Integration {
     void disconnectSignal();
     void enterStandbySignal();
     void leaveStandbySignal();
-    void sendCommandSignal(const QString& type, const QString& entity_id, int command, const QVariant& param);
+    void sendCommandSignal(const QString& type, const QString& entityId, int command, const QVariant& param);
 
  private:
     Integration& m_integration;


### PR DESCRIPTION
Added 2 methods to extend the YIO API functionalities. These methods will help the web configurator to create a drag and drop management interface for entities.

`getAllAvailableEntities` returns a list of available entities. These entities are not controlled by the remote, but available from the integration.

`addAvailableEntity` adds an entity to the list of available entities. It checks if the entity type is supported. If so, it returns true, otherwise false. This is implemented in `integration` class and can be used by all integration implementations.