### PR TITLE
refactor: change `serviceDiscovered` signal return type

### DIFF
--- a/src/yio-interface/configinterface.h
+++ b/src/yio-interface/configinterface.h
@@ -39,6 +39,7 @@
 #define CFG_KEY_DATA_IP "ip"
 #define CFG_KEY_DATA_TOKEN "token"
 #define CFG_KEY_DATA_SSL "ssl"
+#define CFG_KEY_DATA_SSL_IGNORE "ssl_ignore"
 
 /**
  * @brief This interface is implemented by the Entities object and used by integration DLLs to access the entities.

--- a/src/yio-interface/configinterface.h
+++ b/src/yio-interface/configinterface.h
@@ -48,6 +48,8 @@ class ConfigInterface {
  public:
     virtual ~ConfigInterface();
 
+    enum UnitSystem { METRIC = 0, IMPERIAL = 1 };
+
     virtual QVariantMap  getConfig()                             = 0;
     virtual void         setConfig(const QVariantMap& getConfig) = 0;
     virtual QVariantMap  getSettings()                           = 0;
@@ -56,6 +58,7 @@ class ConfigInterface {
     virtual QVariantMap  getAllEntities()                        = 0;
     virtual QVariantList getEntities(const QString& type)        = 0;
     virtual QObject*     getQMLObject(const QString& name)       = 0;
+    virtual UnitSystem   getUnitSystem()                         = 0;
 };
 
 QT_BEGIN_NAMESPACE

--- a/src/yio-interface/yioapiinterface.h
+++ b/src/yio-interface/yioapiinterface.h
@@ -46,7 +46,7 @@ class YioAPIInterface : public QObject {
     virtual void discoverNetworkServices(QString mdns) = 0;
 
  signals:
-    void serviceDiscovered(QMap<QString, QVariantMap> services);
+    void serviceDiscovered(QVariantMap services);
 };
 
 QT_BEGIN_NAMESPACE

--- a/src/yio-plugin/integration.cpp
+++ b/src/yio-plugin/integration.cpp
@@ -35,6 +35,7 @@ const QString Integration::OBJ_DATA               = CFG_OBJ_DATA;
 const QString Integration::KEY_DATA_IP            = CFG_KEY_DATA_IP;
 const QString Integration::KEY_DATA_TOKEN         = CFG_KEY_DATA_TOKEN;
 const QString Integration::KEY_DATA_SSL           = CFG_KEY_DATA_SSL;
+const QString Integration::KEY_DATA_SSL_IGNORE    = CFG_KEY_DATA_SSL_IGNORE;
 
 IntegrationInterface::~IntegrationInterface() {}
 

--- a/src/yio-plugin/integration.h
+++ b/src/yio-plugin/integration.h
@@ -51,6 +51,7 @@ class Integration : public QObject, public IntegrationInterface {
     static const QString KEY_DATA_IP;
     static const QString KEY_DATA_TOKEN;
     static const QString KEY_DATA_SSL;
+    static const QString KEY_DATA_SSL_IGNORE;
 
     Integration(const QVariantMap& config, EntitiesInterface* entities, NotificationsInterface* notifications,
                 YioAPIInterface* api, ConfigInterface* configObj, Plugin* plugin);


### PR DESCRIPTION
Changing the type to a QML readable one, because this signal is also used on the QML side.
Added ignore SSL key to config