### PR TITLE
fix: UnitSystem qml enum handling

### DIFF
--- a/src/yio-interface/configinterface.h
+++ b/src/yio-interface/configinterface.h
@@ -23,6 +23,8 @@
 
 #include <QVariant>
 
+#include "unitsystem.h"
+
 // HELP: anyone knows how to properly define "static const QString" constants across Qt plugin boundaries?
 // Workaround: use plain old macros with separated constant definitions in remote_software and the integration plugin.
 // Hope there's a better way...
@@ -48,17 +50,15 @@ class ConfigInterface {
  public:
     virtual ~ConfigInterface();
 
-    enum UnitSystem { METRIC = 0, IMPERIAL = 1 };
-
-    virtual QVariantMap  getConfig()                             = 0;
-    virtual void         setConfig(const QVariantMap& getConfig) = 0;
-    virtual QVariantMap  getSettings()                           = 0;
-    virtual QVariantMap  getAllIntegrations()                    = 0;
-    virtual QVariantMap  getIntegration(const QString& type)     = 0;
-    virtual QVariantMap  getAllEntities()                        = 0;
-    virtual QVariantList getEntities(const QString& type)        = 0;
-    virtual QObject*     getQMLObject(const QString& name)       = 0;
-    virtual UnitSystem   getUnitSystem()                         = 0;
+    virtual QVariantMap      getConfig() = 0;
+    virtual void             setConfig(const QVariantMap& getConfig) = 0;
+    virtual QVariantMap      getSettings() = 0;
+    virtual QVariantMap      getAllIntegrations() = 0;
+    virtual QVariantMap      getIntegration(const QString& type) = 0;
+    virtual QVariantMap      getAllEntities() = 0;
+    virtual QVariantList     getEntities(const QString& type) = 0;
+    virtual QObject*         getQMLObject(const QString& name) = 0;
+    virtual UnitSystem::Enum getUnitSystem() = 0;
 };
 
 QT_BEGIN_NAMESPACE

--- a/src/yio-interface/unitsystem.h
+++ b/src/yio-interface/unitsystem.h
@@ -1,0 +1,44 @@
+/******************************************************************************
+ *
+ * Copyright (C) 2020 Markus Zehnder <business@markuszehnder.ch>
+ *
+ * This file is part of the YIO-Remote software project.
+ *
+ * YIO-Remote software is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * YIO-Remote software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with YIO-Remote software. If not, see <https://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ *****************************************************************************/
+
+#pragma once
+
+#include <QObject>
+
+/**
+ * @brief Enum class for unit system: metric or imperial.
+ * @details Dedicated class for clearly separated enums and improved QML usability based on
+ * https://www.embeddeduse.com/2017/09/15/passing-enum-properties-between-c-and-qml/
+ *
+ * Note: the "typedef style" described in https://qml.guide/enums-in-qt-qml/ unfortunately doesn't work with
+ * "=== Strict Equality Comparison" in QML!
+ */
+class UnitSystem {
+    Q_GADGET
+
+ public:
+    enum Enum { METRIC = 0, IMPERIAL = 1 };
+    Q_ENUM(Enum)
+
+ private:
+    UnitSystem() {}
+};

--- a/yio-interfaces.pri
+++ b/yio-interfaces.pri
@@ -11,6 +11,7 @@ HEADERS += \
     $$PWD/src/yio-interface/integrationinterface.h \
     $$PWD/src/yio-interface/notificationsinterface.h \
     $$PWD/src/yio-interface/plugininterface.h \
+    $$PWD/src/yio-interface/unitsystem.h \
     $$PWD/src/yio-interface/yioapiinterface.h \
     $$PWD/src/yio-interface/entities/blindinterface.h \
     $$PWD/src/yio-interface/entities/climateinterface.h \


### PR DESCRIPTION
Moved UnitSystem enum from ConfigInterface into dedicated enum class for
type safe QML integration.

Part of YIO-Remote/remote-software#473 and YIO-Remote/remote-software#442

This is breaking interface change and following points must be followed after this PR has been merged:
1. a new release must be created
1. update dependencies in the qml-enums branches of remote-software and integration.openweather
1. create PRs for above's branches