### PR TITLE
Add C_QUEUE command to mediaplayer interface

### DIFF
--- a/src/yio-interface/entities/mediaplayerinterface.h
+++ b/src/yio-interface/entities/mediaplayerinterface.h
@@ -99,7 +99,8 @@ class MediaPlayerDef : public QObject {
         C_SEARCH_ITEM,
         C_PLAY_ITEM,
         C_GETALBUM,
-        C_GETPLAYLIST
+        C_GETPLAYLIST,
+        C_QUEUE
     };
     Q_ENUM(Commands)
 


### PR DESCRIPTION
This PR is needed, as pointed out by @zehnm, in order for the project to successfully compile with queue additions to the Spotify integration: 
- https://github.com/YIO-Remote/remote-software/pull/497
- https://github.com/YIO-Remote/integration.spotify/pull/16